### PR TITLE
Fix for null checks before updating preferences

### DIFF
--- a/source/template.groovy
+++ b/source/template.groovy
@@ -100,7 +100,7 @@ def updated() {
 					state.currentPreferencesState."$it.key".status = "syncPending"
 				}
 			}
-		} else if (!state.currentPreferencesState."$it.key".value) {
+		} else if (state.currentPreferencesState."$it.key".value == null) {
 			log.warn "Preference ${it.key} no. ${it.parameterNumber} has no value. Please check preference declaration for errors."
 		}
 	}


### PR DESCRIPTION
When the parameter default value (integer 0) was set in state - the mechanism treated it as a null when comparing the current preference values and state values - that gave a warning messages: 

log.warn "Preference ${it.key} no. ${it.parameterNumber} has no value. Please check preference declaration for errors."

This pr fixes the problem.
